### PR TITLE
Adds a global template helper for state monitoring

### DIFF
--- a/client/lib.js
+++ b/client/lib.js
@@ -9,6 +9,10 @@ Impersonate.undo = function() {
   if (Impersonate._user) Meteor.connection.setUserId(Impersonate._user);
 }
 
+Handlebars.registerHelper('isImpersonating', function () {
+  return !!Impersonate._user;
+});
+
 Template.body.events({
   "click [data-impersonate]": function(e, data) {
     var userId = $(e.currentTarget).attr("data-impersonate");


### PR DESCRIPTION
Useful if you have a template that should display an un-impersonate button, but only if the user is currently impersonating.
