### PR TITLE
Fix `check` is not defined error

### DIFF
--- a/package.js
+++ b/package.js
@@ -17,6 +17,7 @@ Package.onUse(function (api, where) {
   api.use([
     "random@1.0.5",
     "alanning:roles@1.2.14",
+    "check@1.2.4"
   ]);
 
   api.addFiles([


### PR DESCRIPTION
I got an error which said: 
`Exception while invoking method 'impersonate' ReferenceError: check is not defined
...
`

Just added `check` package as an api requirement fixed that. 

That's all.

